### PR TITLE
Added Electron shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
-# Angular 2 QuickStart Source
-[![Build Status][travis-badge]][travis-badge-url]
+# Electron Angular 2 Quick start
 
 This repository holds the TypeScript source code of the [angular.io quickstart](https://angular.io/docs/ts/latest/quickstart.html),
 the foundation for most of the documentation samples and potentially a good starting point for your application.
 
-It's been extended with testing support so you can start writing tests immediately.
-
-**This is not the perfect arrangement for your application. It is not designed for production.
-It exists primarily to get you started quickly with learning and prototyping in Angular 2**
-
-We are unlikely to accept suggestions about how to grow this QuickStart into something it is not.
-Please keep that in mind before posting issues and PRs.
+This fork has added support for the [Electron](https://github.com/electron/electron) shell, which is very useful when what you are
+building is targetting native platforms (Windows, OS X and Linux).   
 
 ## Prerequisites
 
@@ -25,39 +19,6 @@ Older versions produce errors.
 
 We recommend [nvm](https://github.com/creationix/nvm) for managing multiple versions of node and npm.
 
-## Create a new project based on the QuickStart
-
-Clone this repo into new project folder (e.g., `my-proj`).
-```bash
-git clone  https://github.com/angular/quickstart  my-proj
-cd my-proj
-```
-
-We have no intention of updating the source on `angular/quickstart`.
-Discard everything "git-like" by deleting the `.git` folder.
-```bash
-rm -rf .git  # non-Windows
-rd .git /S/Q # windows
-```
-
-### Create a new git repo
-You could [start writing code](#start-development) now and throw it all away when you're done.
-If you'd rather preserve your work under source control, consider taking the following steps.
-
-Initialize this project as a *local git repo* and make the first commit:
-```bash
-git init
-git add .
-git commit -m "Initial commit"
-```
-
-Create a *remote repository* for this project on the service of your choice.
-
-Grab its address (e.g. *`https://github.com/<my-org>/my-proj.git`*) and push the *local repo* to the *remote*.
-```bash
-git remote add origin <repo-address>
-git push -u origin master
-```
 ## Install npm packages
 
 > See npm and nvm version notes above
@@ -87,7 +48,7 @@ You're ready to write your application.
 
 We've captured many of the most useful commands in npm scripts defined in the `package.json`:
 
-* `npm start` - runs the compiler and a server at the same time, both in "watch mode".
+* `npm start` - runs the compiler and a server at the same time, both in "watch mode". Also starts the Electron shell.
 * `npm run tsc` - runs the TypeScript compiler once.
 * `npm run tsc:w` - runs the TypeScript compiler in watch mode; the process keeps running, awaiting changes to TypeScript files and re-compiling when it sees them.
 * `npm run lite` - runs the [lite-server](https://www.npmjs.com/package/lite-server), a light-weight, static file server, written and maintained by
@@ -149,6 +110,3 @@ A custom reporter (see `protractor.config.js`) generates a  `./_test-output/prot
 which is easier to read; this file is excluded from source control.
 
 Shut it down manually with Ctrl-C.
-
-[travis-badge]: https://travis-ci.org/angular/quickstart.svg?branch=master
-[travis-badge-url]: https://travis-ci.org/angular/quickstart

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -2,6 +2,9 @@ import { Component } from '@angular/core';
 
 @Component({
     selector: 'my-app',
-    template: '<h1>My First Angular 2 App</h1>'
-})
+    template: `
+<h1>My First Angular 2 App</h1>
+<p>Put your app template here. Any changes to this template, or any other file in the \`app\` folder will be automagically
+picked up by the BrowserSync live reload mechanism.</p>
+`})
 export class AppComponent { }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,46 @@
+const electron = require('electron');
+
+// Module to control application life.
+const app = electron.app;
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow: Electron.BrowserWindow;
+
+function createWindow () {
+  mainWindow = new electron.BrowserWindow({ width: 800, height: 600 });
+
+  // We load this over http when running locally to take advantage of BrowserSync. Because the lite-server
+  // usually takes a few seconds to start, we add the 3 second pause.
+  setTimeout(function() {
+    mainWindow.loadURL('http://localhost:3000')
+  }, 3 * 1000);
+
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  });
+};
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow);
+
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "angular2-quickstart",
-  "version": "1.0.0",
+  "name": "angular2-electron-quickstart",
+  "version": "0.0.1",
   "description": "QuickStart package.json from the documentation, supplemented with testing support",
   "scripts": {
-    "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",
+    "start": "tsc && concurrently \"tsc -w\" \"lite-server\" \"electron electron/main.js\"",
     "docker-build": "docker build -t ng2-quickstart .",
     "docker": "npm run docker-build && docker run -it --rm -p 3000:3000 -p 3001:3001 ng2-quickstart",
     "pree2e": "npm run webdriver:update",
     "e2e": "tsc && concurrently \"http-server -s\" \"protractor protractor.config.js\" --kill-others --success first",
+    "electron": "electron",
     "lint": "tslint ./app/**/*.ts -t verbose",
     "lite": "lite-server",
     "postinstall": "typings install",
@@ -58,7 +59,9 @@
     "karma-htmlfile-reporter": "^0.2.2",
     "karma-jasmine": "^0.3.8",
     "protractor": "^3.3.0",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+
+    "electron": "^1.3.4"
   },
   "repository": {}
 }

--- a/typings.json
+++ b/typings.json
@@ -2,6 +2,7 @@
   "globalDependencies": {
     "angular-protractor": "registry:dt/angular-protractor#1.5.0+20160425143459",
     "core-js": "registry:dt/core-js#0.0.0+20160725163759",
+    "github-electron": "registry:dt/github-electron#1.3.4+20160831020201",
     "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
     "node": "registry:dt/node#6.0.0+20160831021119",
     "selenium-webdriver": "registry:dt/selenium-webdriver#2.44.0+20160317120654"


### PR DESCRIPTION
This is a pretty quick hack, but it seems to work quite fine. Live reload using BrowserSync is also fully functional (we are essentially just using the Electron shell as a web browser for http://localhost files at the moment, which is seemingly a quite useful workflow when developing).
